### PR TITLE
Fix reported cases count in pie chart

### DIFF
--- a/app/src/main/java/id/rizmaulana/covid19/ui/adapter/viewholders/OverviewItemViewHolder.kt
+++ b/app/src/main/java/id/rizmaulana/covid19/ui/adapter/viewholders/OverviewItemViewHolder.kt
@@ -28,6 +28,7 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
     private var confirmed: Int = 0
     private var recovered: Int = 0
     private var deaths: Int = 0
+    private var active: Int = 0
 
     private fun startNumberChangeAnimator(finalValue: Int?, view: TextView) {
         val initialValue = NumberUtils.extractDigit(view.text.toString())
@@ -50,30 +51,27 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
     override fun bind(item: OverviewItem) {
         if(item.confirmed == confirmed && item.recovered == recovered && item.deaths == deaths) return
 
-        with(binding){
-            startNumberChangeAnimator(item.confirmed, txtConfirmed)
-            startNumberChangeAnimator(item.deaths, txtDeaths)
-            startNumberChangeAnimator(item.recovered, txtRecovered)
-        }
-
         confirmed = item.confirmed
         recovered = item.recovered
         deaths = item.deaths
+        active = confirmed.minus(recovered).minus(deaths)
+
+        with(binding){
+            startNumberChangeAnimator(confirmed, txtConfirmed)
+            startNumberChangeAnimator(deaths, txtDeaths)
+            startNumberChangeAnimator(recovered, txtRecovered)
+        }
 
         val context = itemView.context
         val pieDataSet = PieDataSet(
             listOf(
-                PieEntry(item.confirmed.toFloat(), context.getString(R.string.confirmed)),
-                PieEntry(item.recovered.toFloat(), context.getString(R.string.recovered)),
-                PieEntry(item.deaths.toFloat(), context.getString(R.string.deaths))
+                PieEntry(active.toFloat(), context.getString(R.string.active)),
+                PieEntry(recovered.toFloat(), context.getString(R.string.recovered)),
+                PieEntry(deaths.toFloat(), context.getString(R.string.deaths))
             ), context.getString(R.string.covid19)
         )
 
-        binding.txtCases.text = NumberUtils.numberFormat(
-            (item.confirmed
-                .plus(item.recovered)
-                .plus(item.deaths))
-        ).toString()
+        binding.txtCases.text = NumberUtils.numberFormat(item.confirmed).toString()
 
         with(binding.root.context) {
             val colors = arrayListOf(
@@ -81,7 +79,6 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
                 color(R.color.color_recovered),
                 color(R.color.color_death)
             )
-
             pieDataSet.colors = colors
         }
 

--- a/app/src/main/java/id/rizmaulana/covid19/ui/adapter/viewholders/OverviewItemViewHolder.kt
+++ b/app/src/main/java/id/rizmaulana/covid19/ui/adapter/viewholders/OverviewItemViewHolder.kt
@@ -42,7 +42,7 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
 
     override fun setOnClickListener(listener: (View) -> Unit) {
         with(binding) {
-            layoutConfirmed.setOnClickListener { listener.invoke(it) }
+            layoutActive.setOnClickListener { listener.invoke(it) }
             layoutRecovered.setOnClickListener { listener.invoke(it) }
             layoutDeath.setOnClickListener { listener.invoke(it) }
         }
@@ -57,7 +57,7 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
         active = confirmed.minus(recovered).minus(deaths)
 
         with(binding){
-            startNumberChangeAnimator(confirmed, txtConfirmed)
+            startNumberChangeAnimator(active, txtActive)
             startNumberChangeAnimator(deaths, txtDeaths)
             startNumberChangeAnimator(recovered, txtRecovered)
         }
@@ -75,7 +75,7 @@ class OverviewItemViewHolder(itemView: View) : BaseViewHolder<OverviewItem>(item
 
         with(binding.root.context) {
             val colors = arrayListOf(
-                color(R.color.color_confirmed),
+                color(R.color.color_active),
                 color(R.color.color_recovered),
                 color(R.color.color_death)
             )

--- a/app/src/main/java/id/rizmaulana/covid19/ui/overview/DashboardActivity.kt
+++ b/app/src/main/java/id/rizmaulana/covid19/ui/overview/DashboardActivity.kt
@@ -81,7 +81,7 @@ class DashboardActivity : BaseActivity() {
         when (viewItem) {
             is OverviewItem -> {
                 when (view.id) {
-                    R.id.layout_confirmed -> permission(CaseType.CONFIRMED)
+                    R.id.layout_active -> permission(CaseType.CONFIRMED)
                     R.id.layout_recovered -> permission(CaseType.RECOVERED)
                     R.id.layout_death -> permission(CaseType.DEATHS)
                 }

--- a/app/src/main/res/layout/item_overview.xml
+++ b/app/src/main/res/layout/item_overview.xml
@@ -74,7 +74,7 @@
             app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_confirmed"
+                android:id="@+id/layout_active"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/space_x3"
@@ -83,7 +83,7 @@
                 android:paddingLeft="@dimen/space_x2">
 
                 <TextView
-                    android:id="@+id/txt_confirmed"
+                    android:id="@+id/txt_active"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/zero"
@@ -95,12 +95,12 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/confirmed"
+                    android:text="@string/active"
                     android:textAppearance="@style/TextAppearance.App.TextView.H5.White.Bold"
-                    android:textColor="@color/color_confirmed"
+                    android:textColor="@color/color_active"
                     android:textSize="@dimen/text_14"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/txt_confirmed" />
+                    app:layout_constraintTop_toBottomOf="@id/txt_active" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -133,7 +133,6 @@
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/txt_recovered" />
 
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -165,7 +164,6 @@
                     android:textSize="@dimen/text_14"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/txt_deaths" />
-
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -18,7 +18,7 @@
     <string name="case_reported">Kejadian dilaporkan</string>
     <string name="tap_on_statistic">Tap pada statistik di sisi sebelah kanan untuk info lebih\nSumber Data : https://covid19.mathdro.id/api/</string>
     <string name="total_case">Total Kasus</string>
-    <string name="active">Active</string>
+    <string name="active">Aktif</string>
     <string name="confirmed">Dikonfirmasi</string>
     <string name="recovered">Pulih</string>
     <string name="deaths">Meninggal</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -18,6 +18,7 @@
     <string name="case_reported">Kejadian dilaporkan</string>
     <string name="tap_on_statistic">Tap pada statistik di sisi sebelah kanan untuk info lebih\nSumber Data : https://covid19.mathdro.id/api/</string>
     <string name="total_case">Total Kasus</string>
+    <string name="active">Active</string>
     <string name="confirmed">Dikonfirmasi</string>
     <string name="recovered">Pulih</string>
     <string name="deaths">Meninggal</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,5 +17,6 @@
 
     <color name="color_death">#F76353</color>
     <color name="color_recovered">#00CC99</color>
+    <color name="color_active">#F2B900</color>
     <color name="color_confirmed">#F2B900</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="case_reported">Cases reported</string>
     <string name="tap_on_statistic">Tap on statistic on the right side for more information\nData source : https://covid19.mathdro.id/api/</string>
     <string name="total_case">Total Case</string>
+    <string name="active">Active</string>
     <string name="confirmed">Confirmed</string>
     <string name="recovered">Recovered</string>
     <string name="deaths">Deaths</string>


### PR DESCRIPTION
confirmed=active+recovered+deaths

The confirmed cases include the number of deaths and recovered cases. Therefore:
1. We should plot the count of active infections instead of confirmed cases.
2. The total reported cases (inside the pie chart) is just the same as the confirmed cases, instead of confirmed+recovered+deaths. 
